### PR TITLE
Ambassador scheme: Include "community" events in description

### DIFF
--- a/rfcs/ambassador-program/overview-for-ambassadors.md
+++ b/rfcs/ambassador-program/overview-for-ambassadors.md
@@ -36,7 +36,7 @@ Ambassador tasks include:
     * Mentorship hours
     * GraphQL Foundation community Discord moderation
 1. **Public Speaking**
-    * Speaking at industry or GraphQL Foundation events about GraphQL or GraphQL projects
+    * Speaking at industry, community or GraphQL Foundation events about GraphQL or GraphQL projects
 1. **GraphQL Focused Content Creation**
     * Producing written content, both on GraphQL Foundation platforms and in other places
     * Have written a GraphQL focused book


### PR DESCRIPTION
I hadn't considered that an "industry" event and a "community" event might be different things, until I wrote it in the application form I am currently drafting. For example, I think FOSDEM is more a "community" event rather than an "industry" event. 