### PR TITLE
Propose date change for September

### DIFF
--- a/agendas/2025/09-Sep/25-community-working-group-september-2025.md
+++ b/agendas/2025/09-Sep/25-community-working-group-september-2025.md
@@ -3,7 +3,7 @@
 
 # Community Working Group — September 2025
 
-- **Date & Time**: [September 11, 2025, 8:00 – 9:00 AM PDT](https://www.timeanddate.com/worldclock/converter.html?iso=20250911T150000&p1=224&p2=179&p3=136&p4=268&p5=367&p6=438&p7=248&p8=240)
+- **Date & Time**: [September 25, 2025, 8:00 – 9:00 AM PDT](https://www.timeanddate.com/worldclock/converter.html?iso=20250924T150000&p1=224&p2=179&p3=136&p4=268&p5=367&p6=438&p7=248&p8=240)
   - View the [calendar][], or subscribe ([Google Calendar][], [ical file][]).
   - _Please Note:_ The date or time may change. Please check this agenda the
     week of the meeting to confirm. While we try to keep all calendars accurate,


### PR DESCRIPTION
The current September date is the day after GraphQL conf, @martinbonnin and I thought it best to change this date. 

I've chosen 25th September as the 18th is earmarked for the secondary main working group day. 

cc @jonathanrainer you'll want to be aware of this date change as you're on the agenda