### PR TITLE
Add an event submission issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/event-submission.yml
+++ b/.github/ISSUE_TEMPLATE/event-submission.yml
@@ -78,7 +78,7 @@ body:
     attributes:
       label: Host link
       description: Website, meetup page, or social profile.
-      placeholder: https://www.meetup.com/amsterdam-graphql-meetup/
+      placeholder: https://
   - type: input
     id: contact
     attributes:


### PR DESCRIPTION
hey 👋 

This PR adds an issue template to power <kbd>Add a new event</kbd> button on the new https://graphql.org/community/events page.

I conflicts with the `#locals` channel a bit, but it provides a worthwhile alternative way to submit events, including conferences, for people unused to Discord.

<img width="661" height="75" alt="image" src="https://github.com/user-attachments/assets/6b765d3e-63a7-4dca-a57b-53c1cc3748c9" />

Later we could set up an automation that scans for approved issues in here and opens a PR to the graphql.org repo, but adding them manually is not a huge lift, so this is the more important part.

@jemgillam Uri told me to add you to assignees in the template. Please let me know if the wording is all right or if you'd like to add/remove something.